### PR TITLE
UltimaThule: fixes based on Valgrind checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ SRC_DIR = src
 OBJ_DIR = build
 BIN_DIR = bin
 TEST_DIR = test
-MOCK_DIR = $(TEST_DIR)/mocks
+# MOCK_DIR = $(TEST_DIR)/mocks
 COVERAGE_DIR = cvg
 
 # Targets
@@ -22,12 +22,12 @@ TEST_TARGET = $(BIN_DIR)/testRunner
 # Sources
 SRCS = $(SRC_DIR)/main.c $(SRC_DIR)/DiningPhilosophers.c
 TEST_SRCS = $(TEST_DIR)/TestDining.c $(SRC_DIR)/DiningPhilosophers.c
-MOCK_SRCS = $(wildcard $(MOCK_DIR)/*.c)
+# MOCK_SRCS = $(wildcard $(MOCK_DIR)/*.c)
 
 # Objects
 OBJS = $(SRCS:$(SRC_DIR)/%.c=$(OBJ_DIR)/%.o)
 TEST_OBJS = $(TEST_SRCS:%.c=$(OBJ_DIR)/%.o)
-MOCK_OBJS = $(MOCK_SRCS:%.c=$(OBJ_DIR)/%.o)
+# MOCK_OBJS = $(MOCK_SRCS:%.c=$(OBJ_DIR)/%.o)
 
 # Look for main.c in src/
 vpath %.c $(SRC_DIR)

--- a/include/DiningPhilosophers.h
+++ b/include/DiningPhilosophers.h
@@ -11,13 +11,16 @@ typedef enum {
     THINKING = 0,
     EATING = 1
 } philosopher_state_t;
+
 /** Violation detection for tests */
 typedef enum {
     OK = 0,
     VIOLATION = 1
 } violation_detection_t;
+
 // forward declaration
 typedef struct simulation simulation_t;
+
 /** Philosopher struct encapsulates each thread's info */
 typedef struct {
     int id;                                     // logging and easy identification
@@ -29,6 +32,7 @@ typedef struct {
     pthread_t thread_id;                        // thread identifier (don't use for math/only use for thread starting/joining etc.)
     simulation_t *sim;                          // points back to the overall simulation context
 } philosopher_t;
+
 /** Simulation context -- full encapsulation, no global variables in this version */
 struct simulation {
     int num_philosophers;

--- a/runValgrind.sh
+++ b/runValgrind.sh
@@ -1,23 +1,48 @@
 #!/bin/bash
 # runvalgrind.sh - Run valgrind on a specified binary (default: bin/testRunner)
 
-# Use the first argument as the binary, or default
-TEST_BIN=${1:-bin/testRunner}
+# Default values
+TOOL="memcheck"
+TEST_BIN="bin/testRunner"
 
-# Shift positional arguments so $@ contains anything after the binary
-shift
+# Parse tool flag
+if [[ $1 == "--helgrind" ]]; then
+    TOOL="helgrind"
+    shift
+elif [[ $1 == "--drd" ]]; then
+    TOOL="drd"
+    shift
+fi
 
-# Check if the binary exists
+# check if the binary path argument is not empty, and if it isn't, make sure it is a file that exists
+if [[ -n $1 && -f $1 ]]; then
+    TEST_BIN=$1
+    shift
+fi
+
+# FYI on shift, moves all positional arguments left, 
+# so make sure that we are handling each before shifting
+
+# Check default or passed argument binary exists
 if [[ ! -f $TEST_BIN ]]; then
     echo "Binary not found: $TEST_BIN"
-    echo "Usage: $0 [path_to_binary] [binary_args]"
+    echo "Usage: $0 [--helgrind|--drd] [path_to_binary] [binary_args...]"
     exit 1
 fi
 
-# Run valgrind
-valgrind \
-    --leak-check=full \
-    --show-leak-kinds=all \
-    --track-origins=yes \
-    --verbose \
-    "$TEST_BIN" "$@"
+echo "Running $TOOL on $TEST_BIN $@"
+
+# Common base
+VALGRIND_CMD=(valgrind --tool="$TOOL" --verbose)
+
+# Add tool-specific flags
+if [[ "$TOOL" == "memcheck" ]]; then
+    VALGRIND_CMD+=(
+        --leak-check=full
+        --show-leak-kinds=all
+        --track-origins=yes
+    )
+fi
+
+# Run
+"${VALGRIND_CMD[@]}" "$TEST_BIN" "$@"

--- a/src/main.c
+++ b/src/main.c
@@ -67,7 +67,6 @@ int main (int argc, char *argv[]) {
     sim->hashi = malloc(sizeof(pthread_mutex_t) * sim->num_philosophers);
     if (!sim->hashi) {
         fprintf(stderr, "ERROR: Failed to allocate for hashi\n");
-        free(sim->hashi);
         free(sim);
 
         return EXIT_FAILURE;
@@ -77,7 +76,6 @@ int main (int argc, char *argv[]) {
     sim->philosophers = malloc(sizeof(philosopher_t) * sim->num_philosophers);
     if (!sim->philosophers) {
         fprintf(stderr, "ERROR: Failed to allocate for philosophers\n");
-        free(sim->philosophers);
         free(sim->hashi);
         free(sim);
 


### PR DESCRIPTION
Ran valgrind memcheck, drd, and helgrind.

--memcheck is and was good
--drd(data race detection) was noting a lot of "errors", but it is just because it can access data from other threads. As written, we shouldn't be able to write
--helgrind I switched to following the guideline of having a global ids that just follow the thread ids, and the lowest values are grabbed before the next highest.

Removed unnecessary frees in main, even though free(NULL) is ok, no need to run it.